### PR TITLE
removed + to stop adding share buttons that dont work

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -418,5 +418,5 @@ i.become-a-consultant {
 
     display: inline;
     position: relative;
-    left: 45.5%;
+    left: 47%;
 }

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -56,18 +56,15 @@
   		      <%= link_to "Destroy", @project, method: :delete, data: { confirm: "Are you sure?" } %> 
 		      <% end %> 
         <br>
-          <p><a href="#" class="btn btn-primary" role="button">Like</a>
-          </p>
-           <!-- AddToAny BEGIN -->
+           <!-- Share Buttons Start -->
           <div class="share">
             <div class="a2a_kit a2a_kit_size_32 a2a_default_style">
-              <a class="a2a_dd" href="https://www.addtoany.com/share"></a>
               <a class="a2a_button_twitter"></a>
               <a class="a2a_button_linkedin"></a>
             </div>
           </div>
-            <script async src="https://static.addtoany.com/menu/page.js"></script>
-            <!-- AddToAny END -->
+          <script async src="https://static.addtoany.com/menu/page.js"></script>
+            <!-- Share Buttons END -->
         </div>
       </div>
       <div class="col-md-1">


### PR DESCRIPTION
Removed the Add button on the social media pages. Stops people trying to add social media that currently don't work with our site. 